### PR TITLE
Enable verify_SSL => 1 on HTTP::Tiny

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   - [X] ~option to~ don't sign commits
   - [X] ~--dry-run~ omit --commit for testing
   - [X] check that branch is not master
-- [ ] add `verify_SSL => 1` to HTTP::Tiny usage
+- [x] add `verify_SSL => 1` to HTTP::Tiny usage
 - corner cases
   - [ ] try to work out errata
   - [X] some cases have distribution as pname, not module

--- a/nix-update-cpan.pl
+++ b/nix-update-cpan.pl
@@ -86,7 +86,7 @@ option file    => "nix_file"       => "(optional) Path to perl-packages.nix" => 
 option bool  => "verbose"    => "Show changes and determinations being made" => 0;
 
 
-our $ua = new HTTP::Tiny::Cache ( agent => "nix-update-perl-packages/$VERSION" );
+our $ua = new HTTP::Tiny::Cache ( agent => "nix-update-perl-packages/$VERSION", verify_SSL => 1 );
 
 app {
     my $app = shift;


### PR DESCRIPTION
This is already done in the default Nixpkgs Perl, but it doesn't hurt to
do it here as well.