### PR TITLE
Drop inExternalNixFiles and ignore->distro

### DIFF
--- a/errata.conf
+++ b/errata.conf
@@ -9,29 +9,8 @@
               Catalyst::Engine::HTTP::Restarter
               Catalyst::Engine::HTTP::Restarter::Watcher
               )
-        ],
-        distro => [
-            qw(
-              Sys-Virt
-              Mac-SystemDirectory
-              Mac-Pasteboard
-              Regexp-Copy
-              Catalyst-Engine-HTTP-Prefork
-              Catalyst-Plugin-HTML-Widget
-              Devel-SizeMe
-              Unicode-ICU-Collator
-              Mail-SPF
-              )
         ]
     },
-    inExternalNixFiles => [
-        qw(
-          Compress-Raw-Zlib
-          DBD-SQLite
-          DBD-Pg
-          DB_File
-          )
-    ],
     extraBuildDependencies => {
         "Alien-GMP"               => ["Devel::CheckLib"],
         "Autodia"                 => ["DBI"],


### PR DESCRIPTION
It's not used and there is no reason we should do that in the future.